### PR TITLE
Choose gdrive folder

### DIFF
--- a/nbgdrive/handlers.py
+++ b/nbgdrive/handlers.py
@@ -11,7 +11,7 @@ from notebook.base.handlers import IPythonHandler
 # 3. File deleted locally are not syncable to the sync directory, this is a bug we must fix
 # 4. The /home directory contains just one folder, called `jovyan`, which is the standard student working directory
 
-SYNC_DIRECTORY = "."
+SYNC_DIRECTORY = "/home/jovyan"
 
 
 def create_sync_directory():

--- a/nbgdrive/static/main.js
+++ b/nbgdrive/static/main.js
@@ -10,7 +10,6 @@ define([
     /*
      *  Updates the Jupyter notebook display to handle the initial Drive authentication.
      */
-    console.log("asfadsfds");
 
     function createDisplayDiv() {
         /* Remove the link elements. */
@@ -72,11 +71,7 @@ define([
                                             message: path,
                                             _xsrf: r ? r[1] : undefined
                                             },
-                                            function(response) {
-
-                                                console.log("asfadsfds");
-
-                                            });
+                                            function(response) {});
 
                                         $.getJSON(utils.get_body_data('baseUrl') + 'createDrive', function(data) {
                                             var display = String(data['status']);

--- a/nbgdrive/static/main.js
+++ b/nbgdrive/static/main.js
@@ -64,6 +64,20 @@ define([
                                         createLogoutButton();
 
                                         /* GET Request to alert Server to create a sync directory. */
+                                        var path = 'data9/micah'
+                                        var r = document.cookie.match("\\b_xsrf=([^;]*)\\b");
+
+                                        $.post(utils.get_body_data('baseUrl') + 'setGDriveFolder',
+                                            {
+                                            message: path,
+                                            _xsrf: r ? r[1] : undefined
+                                            },
+                                            function(response) {
+
+                                                console.log("asfadsfds");
+
+                                            });
+
                                         $.getJSON(utils.get_body_data('baseUrl') + 'createDrive', function(data) {
                                             var display = String(data['status']);
                                         });

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nbgdrive",
-    version='0.8.15',
+    version='0.8.25',
     url="https://github.com/data-8/nbgdrive",
     author="Jeff Gong",
     description="Simple Jupyter extension to allow user to sync files to google drive.",


### PR DESCRIPTION
This pull request lays the backend foundations for choosing a custom google drive folder to sync to.

The path of the custom google drive folder to sync to is passed into a post request in `main.js`, as the variable `path` (currently the path is fixed). The `path` variable is then stored in a hidden local file, `.syncdirectory`, that is then accessed each time nbgdrive performs a sync.